### PR TITLE
 A General Module that contains different methods

### DIFF
--- a/src/GeneralHelpers.php
+++ b/src/GeneralHelpers.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Codeception\Module;
+
+class GeneralHelpers extends \Codeception\Module
+{
+    public function getBaseUrlName(){
+
+        return $this->getModule('WebDriver')->_getUrl();
+
+    }
+}


### PR DESCRIPTION
This is a General Helper that may contains methods that are useful across our tests.

For now it contains one method with name getBaseUrlName. With this method we can retrieve the base url we set in the configuration of Webdriver.

This is very useful for example if we use the seeLink() method. 

This method reads the link we may have in an element. 

But it reads only absolute links. So if the link contain the base url of the test site (which is a variable actually) we cannot have a proper test for checking links.

With gerBaseUrlName we can retrieve the base URL and create the absolute link for the element.

In future we can add more methods that we can help us.